### PR TITLE
Удаление массива зависимостей

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import { DependencyList, useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 type Callback = (...args: unknown[]) => unknown;
-export const useRealMemoCallback = <T extends Callback>(callback: T, deps: DependencyList) => {
+export const useRealMemoCallback = <T extends Callback>(callback: T) => {
     const callbackRef = useRef<T>(callback);
 
     useEffect(() => {
         callbackRef.current = callback;
-    }, deps);
+    });
 
     return useCallback((...args: unknown[]) => {
         return callbackRef.current(...args);


### PR DESCRIPTION
Так как линтер по умолчанию не будет подсвечивать некорректные зависимости, предлагаю пока удалить массив зависимостей.

Чтобы проверка массива работала, нужно писать плагин для линтера.